### PR TITLE
Add LLDP to server

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This demo is written for the [cldemo-vagrant](https://github.com/cumulusnetworks
 
 Quickstart: Run the demo
 ------------------------
-(This assumes you are running Ansible 1.9.4 and Vagrant 1.8.4 on your host.)
+(This assumes you are running Ansible 1.9.4 and Vagrant 1.8.1 on your host.)
 
     git clone https://github.com/cumulusnetworks/cldemo-vagrant
     cd cldemo-vagrant

--- a/roles/lldpctl/tasks/main.yml
+++ b/roles/lldpctl/tasks/main.yml
@@ -1,0 +1,5 @@
+# One of the key tasks of automation are to install and configure services on
+# servers. This example installs lldp daemon
+- name: install lldpd
+  apt: name=lldpd update_cache=yes
+

--- a/run-demo.yml
+++ b/run-demo.yml
@@ -19,6 +19,7 @@
   become_method: sudo
   roles:
     - ifupdown
+    - lldpctl
 - hosts: server02
   user: cumulus
   become: yes


### PR DESCRIPTION
This is a nice-to-have to show the server connectivity into the leafs.  I tested it.  Also fixed the docs to show Vagrant version 1.8.1 (the latest) instead of 1.8.4 (doesn't exist)